### PR TITLE
Use [].push instead of spread syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const filterAndTransform = (filterFn, transformFn) =>
   collection =>
     collection.reduce((acc, curr) => {
       if (filterFn(curr)) {
-        return [...acc, transformFn(curr)];
+        acc.push(transformFn(curr));
       }
       return acc;
     }, []);


### PR DESCRIPTION
Since initial value is not coming from outside I think it's fine
to mutate it in this case by using `.push`, avoiding the creation
of  a new array in every iteration as pointed by @bitriddler.

Fixes #1 